### PR TITLE
[BUGFIX] Distorted Ring Label Text on Mac OSX

### DIFF
--- a/src/graph/labels/LabelAtlas.ts
+++ b/src/graph/labels/LabelAtlas.ts
@@ -161,7 +161,7 @@ export class LabelAtlas {
 
     protected renderCharTexture(char: string, size: number, context: CanvasRenderingContext2D, canvas: HTMLCanvasElement, font: string, bold: boolean): ImageData {
         const pixelRatio = this.labelPixelRatio;
-        const fontString = `${bold ? 'bold ' : ''}${size * pixelRatio}px "${font}"`;
+        const fontString = `${bold ? 'bold ' : ''}${size * pixelRatio}px ${font}`;
 
         if (!this.spaceSizeMap.has(size)) {
             context.font = fontString;


### PR DESCRIPTION
Remove quotation marks encapsulating font string. Quotation marks around Generic Font Families (ie. monospace, sans-serif) must not be quoted according to https://www.w3.org/TR/2018/REC-css-fonts-3-20180920/#propdef-font-family:

```
The following generic family keywords are defined: 'serif', 'sans-serif', 'cursive', 'fantasy', and 'monospace'. These keywords can be used as a general fallback mechanism when an author's desired font choices are not available. As keywords, they must not be quoted.
```

The quotation marks had been causing text distortion issues in Mac OSX. 

Note: Above spec is for CSS and may not fully apply to canvas font styling, however I was unable to find this specific rule in a canvas spec and upon testing it appeared to hold true for canvas as well.