### PR TITLE
[BUG] Define usampler2D precision in value for index util

### DIFF
--- a/src/renderer/shaders/valueForIndex.glsl
+++ b/src/renderer/shaders/valueForIndex.glsl
@@ -1,3 +1,5 @@
+precision lowp usampler2D;
+
 vec4 valueForIndex(sampler2D tex, int index) {
     int texWidth = textureSize(tex, 0).x;
     int col = index % texWidth;


### PR DESCRIPTION
Chrome **97.0.4692.71** requires the precision of `uSampler2D` to be defined within shader files. 

Co-authored-by: Manfred Cheung <mj3cheun@users.noreply.github.com>