### PR TITLE
[VERSION] Upgrade version to 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uncharted.software/grafer",
-    "version": "0.5.3",
+    "version": "0.6.0",
     "description": "Large graph renderer",
     "main": "build/lib/mod.js",
     "types": "build/types/mod.d.ts",


### PR DESCRIPTION
### Overview
Version v0.6.0 makes Grafer compatible with Chrome version 97.x.xxxx.xx+.

### Changes
- [BUGFIX] Correct Color Registry misspelling: https://github.com/uncharted-aske/grafer/pull/43
- [BUGFIX] Define usampler2D precision in value for index util: https://github.com/uncharted-aske/grafer/pull/44

### Considerations
Backward incompatible interface change has been included in this version from v0.5.3:
- Renamed `colorRegisrty` to `colorRegistry`. See associated change here: https://github.com/uncharted-aske/grafer/pull/44

However, as this is pre-release only the MINOR version has been bumped.